### PR TITLE
Add autoplay widget to Final Decode node

### DIFF
--- a/motion_context_disk.py
+++ b/motion_context_disk.py
@@ -2868,6 +2868,7 @@ class MiniMaxH3MotionContextDiskFinalDecode:
                 "crf": ("INT", {"default": 17, "min": 0, "max": 51, "step": 1}),
                 "preset": (["ultrafast", "superfast", "veryfast", "faster", "fast", "medium", "slow"], {"default": "fast"}),
                 "audio_bitrate": (["128k", "192k", "256k", "320k"], {"default": "192k"}),
+                "autoplay": ("BOOLEAN", {"default": True, "tooltip": "Auto-play the video preview when generating finishes or the node is loaded."}),
             },
             "hidden": {"unique_id": "UNIQUE_ID"},
         }

--- a/motion_context_disk.py
+++ b/motion_context_disk.py
@@ -2891,6 +2891,7 @@ class MiniMaxH3MotionContextDiskFinalDecode:
         crf,
         preset,
         audio_bitrate,
+        autoplay=True,
         unique_id=None,
     ):
         data_path, manifest_path, manifest = _load_manifest(cache)

--- a/web/extender.js
+++ b/web/extender.js
@@ -1384,8 +1384,7 @@ async function openClipColorEditor(node, runtime, clipIndex) {
     video.addEventListener("loadedmetadata", () => {
         video.currentTime = loopStart;
         updateLiveFilter();
-        
-        // video.play().catch(() => {}); // Disabled to prevent autoplay
+        video.play().catch(() => {});
     });
     video.addEventListener("timeupdate", () => {
         if (video.currentTime >= loopEnd - 0.015 || video.currentTime < loopStart - 0.05) {

--- a/web/extender.js
+++ b/web/extender.js
@@ -1384,7 +1384,8 @@ async function openClipColorEditor(node, runtime, clipIndex) {
     video.addEventListener("loadedmetadata", () => {
         video.currentTime = loopStart;
         updateLiveFilter();
-        video.play().catch(() => {});
+        
+        // video.play().catch(() => {}); // Disabled to prevent autoplay
     });
     video.addEventListener("timeupdate", () => {
         if (video.currentTime >= loopEnd - 0.015 || video.currentTime < loopStart - 0.05) {

--- a/web/live_preview.js
+++ b/web/live_preview.js
@@ -298,7 +298,10 @@ async function restorePreviewOnLoad(node, state, attempt = 0) {
 
         // Browsers can block autoplay after a page reload. The preview is still
         // immediately visible and ready; play() succeeds when policy allows it.
-        state.video.play().catch(() => {});
+        const autoplayWidget = getWidget(node, "autoplay");
+        if (autoplayWidget && autoplayWidget.value) {
+            state.video.play().catch(() => {});
+        }
         state.restoreLoaded = true;
 
         requestAnimationFrame(() => {
@@ -804,7 +807,11 @@ app.registerExtension({
             state.saveButton.disabled = false;
             state.video.src = mediaUrl(info) + "&t=" + Date.now();
             state.video.load();
-            state.video.play().catch(() => {});
+            
+            const autoplayWidget = getWidget(this, "autoplay");
+            if (autoplayWidget && autoplayWidget.value) {
+                state.video.play().catch(() => {});
+            }
 
             // Do not reset a node the user already enlarged.
             // Only enforce the minimum if necessary, then fit the player


### PR DESCRIPTION
This PR adds an `autoplay` boolean widget to the `MiniMaxH3MotionContextDiskFinalDecode` node to allow users to prevent the video preview from playing automatically.

**Changes:**
- Added `autoplay` widget to `motion_context_disk.py` under the `audio_bitrate` widget. It defaults to `true` to preserve the original intended behavior.
- Updated `web/live_preview.js` (`restorePreviewOnLoad` and `onExecuted`) to conditionally call `.play()` only if the widget value is true.

This gives users the option to avoid unexpected video playback when their node finishes generating or when they restore a workflow, while keeping the default behavior identical for existing users.